### PR TITLE
Template expressions

### DIFF
--- a/Java/src/Java8.ug4
+++ b/Java/src/Java8.ug4
@@ -71,28 +71,16 @@ literal
 	|	nullLiteral
 	;
 integerLiteral => UniIntLiteral
-	:	integerLiteralValue$value
-	;
-integerLiteralValue
-	:	IntegerLiteral
+	:	IntegerLiteral$value
 	;
 floatingPointLiteral => UniDoubleLiteral
-	:	floatingPointLiteralValue$value
-	;
-floatingPointLiteralValue
-	:	FloatingPointLiteral
+	:	FloatingPointLiteral$value
 	;
 booleanLiteral => UniBoolLiteral
-	:	booleanLiteralValue
-	;
-booleanLiteralValue
-	:	BooleanLiteral
+	:	BooleanLiteral$value
 	;
 stringLiteral => UniStringLiteral
-	:	stringLiteralValue
-	;
-stringLiteralValue
-	:	StringLiteral
+	:	StringLiteral$value
 	;
 characterLiteral
 	:	CharacterLiteral
@@ -372,7 +360,7 @@ classMemberDeclaration
 	;
 
 fieldDeclaration => List<UniFieldDec>
-	:	fieldModifiers$modifiers unannType$type fieldVariableDeclaratorList$APPEND ';'
+	:	fieldModifiers$modifiers unannType$type fieldVariableDeclaratorList$ADD ';'
 	;
 fieldModifiers =>List<String>
 	:	fieldModifier*$ADD
@@ -524,7 +512,7 @@ methodName => String
 	;
 
 formalParameterList => List<UniArg>
-	:	formalParameters$APPEND ',' lastFormalParameter$ADD
+	:	formalParameters$ADD ',' lastFormalParameter$ADD
 	|	lastFormalParameter$ADD
 	;
 

--- a/net.unicoen.unimappergenerator/src/net/unicoen/generator/UniMapperGeneratorGenerator.xtend
+++ b/net.unicoen.unimappergenerator/src/net/unicoen/generator/UniMapperGeneratorGenerator.xtend
@@ -39,160 +39,170 @@ class UniMapperGeneratorGenerator implements IGenerator {
 		]
 	}
 
-	def generateImports() '''package net.unicoen.mapper
+	def generateImports() '''
+		package net.unicoen.mapper
+		
+		import java.io.FileInputStream
+		import java.util.ArrayList
+		import java.util.List
+		import org.antlr.v4.runtime.ANTLRInputStream
+		import org.antlr.v4.runtime.CharStream
+		import org.antlr.v4.runtime.CommonTokenStream
+		import org.antlr.v4.runtime.ParserRuleContext
+		import org.antlr.v4.runtime.RuleContext
+		import org.antlr.v4.runtime.tree.ParseTree
+		import org.antlr.v4.runtime.tree.RuleNode
+		import org.antlr.v4.runtime.tree.TerminalNode
+		import net.unicoen.parser.«_grammarName»Lexer
+		import net.unicoen.parser.«_grammarName»Parser
+		import net.unicoen.parser.«_grammarName»BaseVisitor
+		import net.unicoen.node.*
+	'''
 
-import java.io.FileInputStream
-import java.util.ArrayList
-import java.util.List
-import org.antlr.v4.runtime.ANTLRInputStream
-import org.antlr.v4.runtime.CharStream
-import org.antlr.v4.runtime.CommonTokenStream
-import org.antlr.v4.runtime.ParserRuleContext
-import org.antlr.v4.runtime.RuleContext
-import org.antlr.v4.runtime.tree.ParseTree
-import org.antlr.v4.runtime.tree.RuleNode
-import org.antlr.v4.runtime.tree.TerminalNode
-import net.unicoen.parser.«_grammarName»Lexer
-import net.unicoen.parser.«_grammarName»Parser
-import net.unicoen.parser.«_grammarName»BaseVisitor
-import net.unicoen.node.*
-'''
-
-	def generateMapper(Grammar g) {
-		val sb = new StringBuilder
-		sb.nl(generateImports)
-		_indent = 0;
-
-		sb.nl('''class «_grammarName»Mapper extends «_grammarName»BaseVisitor<Object> {''')
-		sb.nl('''var _isDebugMode = false''')
-		sb.nl
-		sb.nl('''new(boolean isDebugMode) {''')
-		sb.nl('''_isDebugMode = isDebugMode''')
-		sb.nl('''}''')
-		sb.nl
-		sb.nl('''def parseFile(String path) {''')
-		sb.nl('''val inputStream = new FileInputStream(path)''')
-		sb.nl('''try {''')
-		sb.nl('''parseCore(new ANTLRInputStream(inputStream))''')
-		sb.nl('''} finally {''')
-		sb.nl('''inputStream.close''')
-		sb.nl('''}''')
-		sb.nl('''}''')
-		sb.nl
-		sb.nl('''def parse(String code) {''')
-		sb.nl('''parseCore(new ANTLRInputStream(code))''')
-		sb.nl('''}''')
-		sb.nl
-		sb.nl('''def parseCore(CharStream chars) {''')
-		sb.nl('''val lexer = new «_grammarName»Lexer(chars)''')
-		sb.nl('''val tokens = new CommonTokenStream(lexer)''')
-		sb.nl('''val parser = new «_grammarName»Parser(tokens)''')
-		if (g.rules.size > 0) {
-			sb.nl('''val tree = parser.«IF g.root != null»«g.root.root.name»«ELSE»«g.rules.get(0).name»«ENDIF»''')
-			sb.nl
-			sb.nl('''tree.visit''')
-		}
-		sb.nl('''}''')
-		sb.nl
-		sb.nl('''override public visitChildren(RuleNode node) {''')
-		sb.nl('''val n = node.childCount;''')
-		sb.nl('''(0 ..< n).fold(defaultResult) [ acc, i |''')
-		sb.nl('''if (!node.shouldVisitNextChild(acc)) {''')
-		sb.nl('''acc''')
-		sb.nl('''} else {''')
-		sb.nl('''val c = node.getChild(i)''')
-		sb.nl('''val childResult = c.visit''')
-		sb.nl('''acc.aggregateResult(childResult)''')
-		sb.nl('''}''')
-		sb.nl(''']''')
-		sb.nl('''}''')
-		sb.nl
-		sb.nl('''override public visit(ParseTree tree) {''')
-		sb.nl('''if (_isDebugMode) {''')
-		sb.nl('''if (!(tree instanceof ParserRuleContext)) {''')
-		sb.nl('''return visitTerminal(tree as TerminalNode)''')
-		sb.nl('''}''')
-		sb.nl('''val ruleName = «_grammarName»Parser.ruleNames.get((tree as ParserRuleContext).ruleIndex)''')
-		sb.nl('''println("*** visit" + ruleName + " ***")''')
-		sb.nl('''println(tree.text)''')
-		sb.nl('''val ret = tree.accept(this)''')
-		sb.nl('''println("returned: " + ret)''')
-		sb.nl('''ret''')
-		sb.nl('''} else {''')
-		sb.nl('''tree.accept(this)''')
-		sb.nl('''}''')
-		sb.nl('''}''')
-		sb.nl
-		g.rules.filter(ParserRule).forEach [
-			if (it.type != null) {
-				if (it.type.list.bind.endsWith("Literal")) {
-					sb.append(it.makeLiteralMethod)
-				} else {
-					sb.append(it.makeVisitMethod)
+	def generateMapper(Grammar g) '''
+		«generateImports»
+		
+		class «_grammarName»Mapper extends «_grammarName»BaseVisitor<Object> {
+			var _isDebugMode = false
+		
+			new(boolean isDebugMode) {
+				_isDebugMode = isDebugMode
+			}
+		
+			def parse(String code) {
+				parseCore(new ANTLRInputStream(code));
+			}
+		
+			def parseFile(String path) {
+				val inputStream = new FileInputStream(path);
+				try {
+					parseCore(new ANTLRInputStream(inputStream));
+				} finally {
+					inputStream.close();
 				}
 			}
-		]
-		sb.nl('}')
-		sb.toString
-	}
+		
+			def parseCore(CharStream chars) {
+				parseCore(chars, [parser|parser.compilationUnit()])
+			}
+		
+			def parse(String code, Function1<«_grammarName»Parser, ParseTree> parseAction) {
+				parseCore(new ANTLRInputStream(code), parseAction);
+			}
+		
+			def parseFile(String path, Function1<«_grammarName»Parser, ParseTree> parseAction) {
+				val inputStream = new FileInputStream(path);
+				try {
+					parseCore(new ANTLRInputStream(inputStream), parseAction);
+				} finally {
+					inputStream.close();
+				}
+			}
+		
+			def parseCore(CharStream chars, Function1<JavaParser, ParseTree> parseAction) {
+				val lexer = new «_grammarName»Lexer(chars);
+				val tokens = new CommonTokenStream(lexer);
+				val parser = new «_grammarName»Parser(tokens);
+				val tree = parseAction.apply(parser) // parse
+				«IF g.rules.size > 0»
+					tree.visit
+      			«ENDIF»
+			}
+
+			override public visitChildren(RuleNode node) {
+				val n = node.childCount;
+				(0 ..< n).fold(defaultResult) [ acc, i |
+					if (!node.shouldVisitNextChild(acc)) {
+						acc
+					} else {
+						val c = node.getChild(i)
+						val childResult = c.visit
+						acc.aggregateResult(childResult)
+					}
+				]
+			}
+		
+			override public visit(ParseTree tree) {
+				if (_isDebugMode) {
+					if (!(tree instanceof ParserRuleContext)) {
+						return visitTerminal(tree as TerminalNode)
+					}
+					val ruleName = «_grammarName»Parser.ruleNames.get((tree as ParserRuleContext).ruleIndex)
+					println("*** visit" + ruleName + " ***")
+					println(tree.text)
+					val ret = tree.accept(this)
+					println("returned: " + ret)
+					ret
+				} else {
+					tree.accept(this)
+				}
+			}
+			
+			«FOR r : g.rules.filter(ParserRule)»
+				«IF r.type != null»
+					«IF r.type.list.bind.endsWith("Literal")»
+						«r.makeLiteralMethod»
+					«ELSE»
+						«r.makeVisitMethod»
+					«ENDIF»
+				«ENDIF»
+			«ENDFOR»
+		}
+	'''
 
 	def toCamelCase(String str) {
 		Character.toUpperCase(str.charAt(0)) + str.substring(1)
 	}
 
 	def makeVisitMethod(ParserRule r) {
-		val sb = new StringBuilder
 		val ruleName = r.name.toCamelCase
-		sb.nl('''override public visit«ruleName»(«_grammarName»Parser.«ruleName»Context ctx) {''')
 		val typeName = r.type.list.bind
-		if (typeName.startsWith("Uni")) {
-			val packagePrefix = UniNode.package.name + '.'
-			sb.append(r.makeMethodBody(Class.forName(packagePrefix + typeName)))
-		} else if (typeName.startsWith("List")) {
-			val itemClassName = typeName.substring(typeName.indexOf('<') + 1, typeName.indexOf('>'))
-			sb.append(r.makeListMethodBody(itemClassName))
-		} else if (typeName.equals("String")) {
-			sb.append(r.makeStringMethodBody)
-		} else {
-			die("Unknown Class Name: " + typeName)
-		}
-		sb.nl('''}''')
-		sb.nl
-		sb
+		'''
+			override public visit«ruleName»(«_grammarName»Parser.«ruleName»Context ctx) {
+				«IF typeName.startsWith("Uni")»
+					«val fullTypeName = UniNode.package.name + '.' + typeName»
+					«r.makeMethodBody(Class.forName(fullTypeName))»
+				«ELSEIF typeName.startsWith("List")»
+					«val itemClassName = typeName.substring(typeName.indexOf('<') + 1, typeName.indexOf('>'))»
+					«r.makeListMethodBody(itemClassName)»
+				«ELSEIF typeName == "String"»
+					«r.makeStringMethodBody»
+				«ELSE»
+					«die("Unknown Class Name: " + typeName)»
+				«ENDIF»
+			}
+		'''
 	}
 
 	def makeCaseStatement(ParserRule r, Element obj, String fieldTypeName, String fieldName, StringBuilder sb,
 		String returnType) {
 		val rule = obj.eAllContents.filter(RuleRef).head
-		if (rule != null) {
-			val ruleName = rule.reference.name.toCamelCase
-			if (fieldTypeName.startsWith("java.util.List")) {
-				sb.nl('''case «r.getInvokingState(obj)»: {''')
-				val refType = obj.referenceReturnType
-				if (refType == null) {
-					die("Rule " + ruleName + " does not have return type.")
-				}
-				if (refType.startsWith("List")) {
-					sb.nl('''if (bind.«fieldName» == null) {''')
-					sb.nl('''bind.«fieldName» = it.visit as «fieldTypeName»''')
-					sb.nl('''} else {''')
-					sb.nl('''bind.«fieldName» += it.visit as «fieldTypeName»''')
-					sb.nl('''}''')
-				} else {
-					sb.nl('''if (bind.«fieldName» == null) {''')
-					sb.nl('''bind.«fieldName» = new ArrayList<«refType»>''')
-					sb.nl('''}''')
-					sb.nl('''bind.«fieldName» += it.visit as «refType»''')
-				}
-				sb.nl('''}''')
-			} else {
-				sb.nl('''case «r.getInvokingState(obj)»: {''')
-				sb.nl('''bind.«fieldName» = it.visit as «fieldTypeName»''')
-				sb.nl('''}''')
+		if (rule == null) { die("Unreach") }
+		val ruleName = rule.reference.name.toCamelCase
+		'''
+			case «r.getInvokingState(obj)»: {
+				«IF fieldTypeName.startsWith("java.util.List")»
+					«val refType = obj.referenceReturnType»
+					«IF refType == null»
+						«die("Rule " + ruleName + " does not have return type.")»
+					«ENDIF»
+					«IF refType.startsWith("List")»
+						if (bind.«fieldName» == null) {
+							bind.«fieldName» = it.visit as «fieldTypeName»
+						} else {
+							bind.«fieldName» += it.visit as «fieldTypeName»
+						}
+					«ELSE»
+						if (bind.«fieldName» == null) {
+							bind.«fieldName» = new ArrayList<«refType»>
+						}
+						bind.«fieldName» += it.visit as «refType»
+					«ENDIF»
+				«ELSE»
+					bind.«fieldName» = it.visit as «fieldTypeName»
+				«ENDIF»
 			}
-			return
-		}
-		die("Unreach")
+		'''
 	}
 
 	def makeMethodBody(ParserRule r, Class<?> clazz) {

--- a/net.unicoen.unimappergenerator/src/net/unicoen/validation/UniMapperGeneratorValidator.xtend
+++ b/net.unicoen.unimappergenerator/src/net/unicoen/validation/UniMapperGeneratorValidator.xtend
@@ -25,31 +25,27 @@ class UniMapperGeneratorValidator extends AbstractUniMapperGeneratorValidator {
 			if (it.op == null) {
 				return
 			}
-			val ruleName = ((it.body as Atom).body as RuleRef).reference.name
-			switch it.op {
-				case "TODO": {
-					warning('not Implemented: ' + ruleName + ' in ' + r.name, it, Literals.ELEMENT__OP)
-				}
-				case "ADD":
-					r.checkAddTarget(it)
-				case "APPEND":
-					return
-				case "RETURN":
-					return
-				case "MERGE":
-					r.checkMergeTarget(it, ruleName)
-				default: {
-					r.checkField(it)
+			val body = (it.body as Atom).body
+			if (body instanceof RuleRef) {
+				val ruleName = body.reference.name
+				switch it.op {
+					case "TODO": {
+						warning('not Implemented: ' + ruleName + ' in ' + r.name, it, Literals.ELEMENT__OP)
+					}
+					case "ADD":
+						return
+					case "APPEND":
+						return
+					case "RETURN":
+						return
+					case "MERGE":
+						r.checkMergeTarget(it, ruleName)
+					default: {
+						r.checkField(it)
+					}
 				}
 			}
 		]
-
-	}
-
-	def checkAddTarget(ParserRule rule, Element elem) {
-		if (!rule.type.list.bind.contains("List")) {
-			error('Type ' + rule.type.list.bind + ' is not List.', elem, Literals.UNICOEN_TYPE_LIST__BIND)
-		}
 	}
 
 	def checkMergeTarget(ParserRule rule, Element elem, String ruleName) {

--- a/net.unicoen.unimappergenerator/src/net/unicoen/validation/UniMapperGeneratorValidator.xtend
+++ b/net.unicoen.unimappergenerator/src/net/unicoen/validation/UniMapperGeneratorValidator.xtend
@@ -34,8 +34,6 @@ class UniMapperGeneratorValidator extends AbstractUniMapperGeneratorValidator {
 					}
 					case "ADD":
 						return
-					case "APPEND":
-						return
 					case "RETURN":
 						return
 					case "MERGE":


### PR DESCRIPTION
- `StringBuilder`の代わりにtemplate expressionsを使ってコード生成処理を書き換えた
- `makeLiteralMethod`を実装した．それに伴い，文法ファイルを簡素化した．
- `APPEND`と`ADD`の区別が不要なように修正して，`ADD`に統一した．
