### PR TITLE
カンマで区切った変数宣言だとList<UniExpr>にうまくAddされない問題について。

### DIFF
--- a/net.unicoen.unimappergenerator/src/net/unicoen/generator/UniMapperGeneratorGenerator.xtend
+++ b/net.unicoen.unimappergenerator/src/net/unicoen/generator/UniMapperGeneratorGenerator.xtend
@@ -590,6 +590,17 @@ class UniMapperGeneratorGenerator implements IGenerator {
 									«val invokingState = r.getInvokingState»
 									«IF stateList.add(invokingState)»
 										case «invokingState»: {
+											«if (it.op == "MERGE") it.op.toLowerCase 
+											else if (it.op == "ADD")
+"val results = it.visit.flatten
+if(results instanceof ArrayList<?>){
+	for (result: results)
+		add += result
+}
+else
+	add"
+											else if (it.op == "RETURN") "ret" 
+											else it.op» += it.visit
 											«if (it.op == "MERGE" || it.op == "ADD") it.op.toLowerCase else if (it.op == "RETURN") "ret" else it.op» += it.visit
 										}
 									«ENDIF»

--- a/net.unicoen.unimappergenerator/src/net/unicoen/generator/UniMapperGeneratorGenerator.xtend
+++ b/net.unicoen.unimappergenerator/src/net/unicoen/generator/UniMapperGeneratorGenerator.xtend
@@ -601,7 +601,6 @@ else
 	add"
 											else if (it.op == "RETURN") "ret" 
 											else it.op» += it.visit
-											«if (it.op == "MERGE" || it.op == "ADD") it.op.toLowerCase else if (it.op == "RETURN") "ret" else it.op» += it.visit
 										}
 									«ENDIF»
 								«ENDIF»


### PR DESCRIPTION
`List<UniExpr>`にList`<UniVariableDec>`を$addしようとすると`List<UniVariableDec>`の最初の要素しか追加されないため、$addするときにListの場合は一つずつ追加するようにUniMapperGeneratorGenerator.xtend側で対応したいと思いました。

以下、具体的な状況の例です。

関数の引数や複数変数の同時宣言(int a,b,c; など)
はUniVariableDecのList{UniVariableDec(int,a),UniVariableDec(int,b),UniVariableDec(int,c)}としてRETURNされていきますが、statementseqの`List<UniExpr>`へのADDの時に先頭のa以外(b,c)が無くなってしまいました。

今回の変更によってb,cもADDで処理されるようになりましたが他の状況で意図しない動作になるかもしれません。

```
(CPP14.ug4)
compoundstatement => UniBlock
:
'{' statementseq?$body '}'
;

statementseq => List<UniExpr>
:
statement$ADD statement$ADD
;
statement
:
variabledeclarationstatement$RETURN
;

variabledeclarationstatement => List<VariableDec>
:
variabledeclaration$RETURN ';'
;

variabledeclaration => List<UniVariableDec>
:
attributespecifierseq? declspecifierseqwithouttype?$modifiers 
typespecifier$type ptroperator*$type variableDeclaratorList?$MERGE
;

variableDeclaratorList
:
| variableDeclarator$ADD (',' variableDeclarator$ADD)*
;
```
